### PR TITLE
v0.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ The sections should follow the order `Packaging`, `Added`, `Changed`, `Fixed` an
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.5.2
+
+### Security
+
+- Bump build-dependency [h2](https://github.com/hyperium/h2/releases/tag/v0.3.24) from 0.3.22 to 0.3.24 which addresses:
+  - Limit error resets for misbehaving connections
+
 ## 0.5.1
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -165,12 +165,13 @@ dependencies = [
 
 [[package]]
 name = "docker-autoheal"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "bollard",
  "chrono",
  "futures",
  "getopts",
+ "h2",
  "rustls",
  "tokio",
 ]
@@ -313,9 +314,9 @@ checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 
 [[package]]
 name = "h2"
-version = "0.3.22"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d6250322ef6e60f93f9a2162799302cd6f68f79f6e5d85c8c16f14d1d958178"
+checksum = "bb2c4422095b67ee78da96fbb51a4cc413b3b25883c7717ff7ca1ab31022c9c9"
 dependencies = [
  "bytes",
  "fnv",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "docker-autoheal"
-version = "0.5.1"
+version = "0.5.2"
 authors = ["Travis M Knight"]
 license = "MIT"
-description = "Monitor and restart unhealthy docker containers"
+description = "A cross-platform tool to monitor and remediate unhealthy Docker containers"
 readme = "README.md"
 homepage = "https://github.com/tmknight/docker-autoheal"
 edition = "2021"
@@ -16,6 +16,9 @@ futures = "0.3.*"
 rustls = "0.22.*"
 tokio = { version = "1.*", features = ["full"] }
 getopts = "0.2.*"
+
+[build-dependencies]
+h2 = "0.3.24"
 
 [[bin]]
 name = "docker-autoheal"


### PR DESCRIPTION
- Bump build-dependency [h2](https://github.com/hyperium/h2/releases/tag/v0.3.24) from 0.3.22 to 0.3.24 which addresses:
  - Limit error resets for misbehaving connections