### PR TITLE
Only publish on commit

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -9,8 +9,8 @@ on:
     workflows: ["Github Release"]
     types: [completed]
     branches: [main]
-  schedule:
-    - cron: '40 05 * * *'
+  push:
+    branches: [main]
 
 env:
   # Use docker.io for Docker Hub if empty
@@ -31,7 +31,7 @@ jobs:
 
   push-to-registry:
     name: "Publish Docker image"
-    if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' || github.event_name == 'push' }}
     needs:
       - "get-version"
     runs-on: ubuntu-latest
@@ -88,7 +88,7 @@ jobs:
             type=ref,event=branch,enable=${{ github.ref_name != 'main' }}
             type=ref,event=tag
             type=raw,enable=${{ !startsWith(github.ref_name, 'dev') }},value=latest
-            type=raw,enable=${{ github.event_name != 'schedule' && !startsWith(github.ref_name, 'dev') }},priority=1000,value=${{ needs.get-version.outputs.pkg-version }}
+            type=raw,enable=${{ github.event_name != 'push' && !startsWith(github.ref_name, 'dev') }},priority=1000,value=${{ needs.get-version.outputs.pkg-version }}
 
       # Build and push Docker image with Buildx (don't push on PR)
       # https://github.com/docker/build-push-action


### PR DESCRIPTION
When the `latest` tag is pushed on a daily schedule, users using watchtower (or other auto-updaters for Docker) will pull a new version each day, although it is likely identical to the previous version.

This PR changes the GitHub workflow to only automatically publish new image versions on code changes to this repository.