### PR TITLE
Update CHANGELOG to remove obsolete entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 ### Changed
 
 - Upgrade to `Bollard` current release (several breaking changes ahead)
-- Remediate exited containers that should be running
-
 
 ## 0.13.13
 


### PR DESCRIPTION
Removed a line about remediating exited containers as docker restart policy on-failure[:max-retries] should be used